### PR TITLE
Improve Three.js example and ensure visualization

### DIFF
--- a/3PLab2_Code_ReyesShadya/Style.css
+++ b/3PLab2_Code_ReyesShadya/Style.css
@@ -1,1 +1,4 @@
-body { margin: 0; }
+body {
+  margin: 0;
+  overflow: hidden;
+}

--- a/3PLab2_Code_ReyesShadya/index.html
+++ b/3PLab2_Code_ReyesShadya/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>ThreeBásico</title>
+  <link rel="stylesheet" href="Style.css" />
 </head>
 <body>
   <!-- Cargar Three.js desde CDN -->

--- a/3PLab2_Code_ReyesShadya/main.js
+++ b/3PLab2_Code_ReyesShadya/main.js
@@ -12,13 +12,25 @@ camera.position.z = 7; // Alejar la cámara para que se vean todos los objetos
 
 // Crear el renderizador
 const renderer = new THREE.WebGLRenderer();
+renderer.setPixelRatio(window.devicePixelRatio);
 renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setClearColor(0xeeeeee);
 document.body.appendChild(renderer.domElement);
+
+// Ajustar el lienzo cuando se cambie el tamaño de la ventana
+window.addEventListener("resize", () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});
 
 // Añadir una luz
 const light = new THREE.PointLight(0xffffff, 1); // color blanco, intensidad 1
 light.position.set(10, 10, 10);
 scene.add(light);
+
+const ambientLight = new THREE.AmbientLight(0x404040);
+scene.add(ambientLight);
 
 // Cubo
 const geometryCubo = new THREE.BoxGeometry();


### PR DESCRIPTION
## Summary
- Link stylesheet and reset body margin for clean canvas
- Add resizing, clearer background, and ambient light to Three.js scene

## Testing
- `curl -I http://localhost:8000/index.html`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689166c83e288332946400f37f2d2699