### PR TITLE
Improve Three.js example and ensure visualization

### DIFF
--- a/3PLab2_Code_ReyesShadya/Style.css
+++ b/3PLab2_Code_ReyesShadya/Style.css
@@ -1,1 +1,4 @@
-body { margin: 0; }
+body {
+  margin: 0;
+  overflow: hidden;
+}

--- a/3PLab2_Code_ReyesShadya/index.html
+++ b/3PLab2_Code_ReyesShadya/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>ThreeBásico</title>
+  <link rel="stylesheet" href="Style.css" />
 </head>
 <body>
   <!-- Cargar Three.js desde CDN -->

--- a/3PLab2_Code_ReyesShadya/main.js
+++ b/3PLab2_Code_ReyesShadya/main.js
@@ -12,38 +12,45 @@ camera.position.z = 7; // Alejar la cámara para que se vean todos los objetos
 
 // Crear el renderizador
 const renderer = new THREE.WebGLRenderer();
+renderer.setPixelRatio(window.devicePixelRatio);
 renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setClearColor(0xffffff);
 document.body.appendChild(renderer.domElement);
+
+// Ajustar el lienzo cuando se cambie el tamaño de la ventana
+window.addEventListener("resize", () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});
 
 // Añadir una luz
 const light = new THREE.PointLight(0xffffff, 1); // color blanco, intensidad 1
 light.position.set(10, 10, 10);
 scene.add(light);
 
+const ambientLight = new THREE.AmbientLight(0x404040);
+scene.add(ambientLight);
+
+// Material rosa para todas las figuras
+const pinkMaterial = new THREE.MeshStandardMaterial({ color: 0xffc0cb });
+
 // Cubo
-const geometryCubo = new THREE.BoxGeometry();
-const materialCubo = new THREE.MeshStandardMaterial({ color: 0x0077ff });
-const cube = new THREE.Mesh(geometryCubo, materialCubo);
+const cube = new THREE.Mesh(new THREE.BoxGeometry(), pinkMaterial);
 scene.add(cube);
 
 // Esfera
-const geometryEsfera = new THREE.SphereGeometry(0.5, 32, 32);
-const materialEsfera = new THREE.MeshStandardMaterial({ color: 0xff0000 });
-const esfera = new THREE.Mesh(geometryEsfera, materialEsfera);
+const esfera = new THREE.Mesh(new THREE.SphereGeometry(0.5, 32, 32), pinkMaterial);
 esfera.position.x = -2; // mover a la izquierda
 scene.add(esfera);
 
 // Cono
-const geometryCono = new THREE.ConeGeometry(0.5, 1, 32);
-const materialCono = new THREE.MeshStandardMaterial({ color: 0x00ff00 });
-const cono = new THREE.Mesh(geometryCono, materialCono);
+const cono = new THREE.Mesh(new THREE.ConeGeometry(0.5, 1, 32), pinkMaterial);
 cono.position.x = 2; // mover a la derecha
 scene.add(cono);
 
 // Toroide
-const geometryToroide = new THREE.TorusGeometry(0.4, 0.15, 16, 100);
-const materialToroide = new THREE.MeshStandardMaterial({ color: 0xffff00 });
-const toroide = new THREE.Mesh(geometryToroide, materialToroide);
+const toroide = new THREE.Mesh(new THREE.TorusGeometry(0.4, 0.15, 16, 100), pinkMaterial);
 toroide.position.y = -2; // mover hacia abajo
 scene.add(toroide);
 
@@ -51,18 +58,25 @@ scene.add(toroide);
 function animate() {
   requestAnimationFrame(animate);
 
+  const time = performance.now() * 0.001;
+
   // Cubo rota en X y Y
   cube.rotation.x += 0.01;
   cube.rotation.y += 0.01;
+  cube.position.y = Math.sin(time) * 1;
 
   // Esfera rota en Y
   esfera.rotation.y += 0.03;
+  esfera.position.x = -2 + Math.cos(time * 1.5) * 0.5;
 
   // Cono rota en X
   cono.rotation.x += 0.02;
+  cono.position.y = Math.cos(time) * 1;
 
   // Toroide rota en Z
   toroide.rotation.z += 0.04;
+  toroide.position.x = Math.sin(time * 1.2) * 1.5;
+  toroide.position.y = -2 + Math.cos(time * 1.2) * 0.5;
 
   // Renderizar la escena
   renderer.render(scene, camera);


### PR DESCRIPTION
## Summary
- Link stylesheet and reset body margin for clean canvas
- Add resizing, clearer background, and ambient light to Three.js scene
- Animate every shape with time-based motion and apply a minimalist pink palette

## Testing
- `python -m http.server 8000 & curl -I http://localhost:8000/index.html`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689166c83e288332946400f37f2d2699